### PR TITLE
Support deep state properties

### DIFF
--- a/src/revue.js
+++ b/src/revue.js
@@ -1,5 +1,5 @@
 // to valid and match like `a as x.y.z`
-const re = /^([a-zA-Z0-9_-]+)\s{1,2}as\s{1,2}([a-zA-Z0-9\._-]+)$/i
+const re = /^([\w-]+)\s+as\s+([\w\.-]+)$/i
 
 const isDev = process.env.NODE_ENV !== 'production'
 

--- a/src/revue.js
+++ b/src/revue.js
@@ -1,5 +1,5 @@
 // to valid and match like `a as x.y.z`
-const re = /^([\w-]+)\s+as\s+([\w\.-]+)$/i
+const re = /^([\w\.-]+)\s+as\s+([\w\.-]+)$/i
 
 const isDev = process.env.NODE_ENV !== 'production'
 
@@ -13,6 +13,10 @@ function parseProp(prop) {
 	}
 	return {storeProp, realProp}
 }
+
+function deepProp(obj, path){
+	return path.split('.').reduce((o, p) => o[p], obj);
+};
 
 /**
  * Bind reduxStore to Vue instance
@@ -28,8 +32,7 @@ function bindVue(Vue, store) {
 					this._bindProps.forEach(prop => {
 						const {storeProp, realProp} = prop
 						if (realProp && storeProp) {
-							const currentValue = store.getState()[storeProp]
-							this.$set(realProp, currentValue)
+							this.$set(realProp, deepProp(store.getState(), storeProp))
 						}
 					})
 				}
@@ -48,7 +51,7 @@ function bindVue(Vue, store) {
 		this._bindProps = this._bindProps || []
 		prop = parseProp(prop)
 		this._bindProps.push(prop)
-		return store.getState()[prop.storeProp]
+		return deepProp(store.getState(), prop.storeProp)
 	}
 }
 

--- a/test.js
+++ b/test.js
@@ -60,7 +60,7 @@ describe('main', () => {
       done()
     }, 1000)
   })
-  it('test deep property', done => {
+  it('test deep vm property', done => {
     const vm = new Vue({
       data() {
           return {
@@ -77,6 +77,23 @@ describe('main', () => {
         }
     })
     vm.$data.foo.fakeAdmin.info.name.should.equal('sox')
+    done()
+  })
+  it('test deep state property', done => {
+    const vm = new Vue({
+      data() {
+          return {
+            name: this.$select('admin.info.name as name')
+          }
+        },
+        created() {
+          store.dispatch({
+            type: 'CHANGE_NAME',
+            name: 'sox'
+          })
+        }
+    })
+    vm.$data.name.should.equal('sox')
     done()
   })
 })


### PR DESCRIPTION
I was looking for the reverse of:

```
data() {
  return {
    foo: {
    	fakeAdmin: this.$select('admin as foo.fakeAdmin')
    }
  }
}
```

allowing a deeply nested state property to be bound to a top (or deeply nested) property of the Vue:

```
data() {
  return {
    name: this.$select('admin.info.name as name')
  }
}
```

This PR adds this functionality.